### PR TITLE
improvement: add custom  webpack configuration

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	publicPath: './',
+	configureWebpack: {
+		module: {
+			rules: [
+				{
+					test: [/cldr\/.*\.json$/, /.*\.properties$/],
+					loader: 'file-loader',
+					options: {
+						name: 'static/media/[name].[hash:8].[ext]',
+					},
+					type: 'javascript/auto'
+				}
+			]
+		}
+	}
+};


### PR DESCRIPTION
This PR improves the bundling of the assets that are used by the web components (like translations, locale specific data for the calendars). 

Currently (with no custom webpack configuration) they are inlined all. 
However, they are language specific so you never need all of them at runtime (if we inline the CLDR data for the calendars, the bundle size grows from 135 KB to 1.6 MB). So we chose to fetch these resources dynamically at runtime.
 
For this option, we would have to know the URLs, so we can fetch the specific file according to the current language. 

This custom configuration is explained in [our sample project](https://github.com/SAP/ui5-webcomponents-sample-vue#configure-vue-build)